### PR TITLE
docs: update the code of sensors

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ apt-get install lm-sensors
 
 搜索：`$res->{pveversion} = PVE::pvecfg::package()`
 
-在这个定义的下方添加：`$res->{thermalstate} = `sensors`;`
+在这个定义的下方添加：```$res->{thermalstate} = `sensors`;```
 
 结果如图：
 


### PR DESCRIPTION
补充文档上获取CPU温度代码文档部分，原代码由于```"`"```的存在，导致显示出的真实代码缺失了```"`"```