### PR TITLE
Update HDD temperature retrieval method in pve.sh

### DIFF
--- a/pve.sh
+++ b/pve.sh
@@ -662,8 +662,8 @@ cat > $tmpf << 'EOF'
         $res->{thermalstate} = `sensors`;
         $res->{cpusensors} = `cat /proc/cpuinfo | grep MHz && lscpu | grep MHz`;
 
-        $res->{hdd_temperatures} = `smartctl -a /dev/sd?|grep -E "Device Model|Capacity|Power_On_Hours|Temperature"`;
-
+        $res->{hdd_temperatures} = `for disk in /dev/sd[a-z]; do smartctl -a \$disk; done | grep -E "Device Model|Capacity|Power_On_Hours|Temperature"`;
+		
         my $powermode = `cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor && turbostat -S -q -s PkgWatt -i 0.1 -n 1 -c package | grep -v PkgWatt`;
         $res->{cpupower} = $powermode;
 


### PR DESCRIPTION

https://github.com/xiangfeidexiaohuo/pve-diy/issues/16 这个问题我也遇到了，同样sata固态+机械两块硬盘的组合，我测试了一下，有多块盘的时候直接是报错了，导致界面提示“未安装硬盘”
```bash
root@pve:~# smartctl -a /dev/sd?
smartctl 7.4 2024-10-15 r5620 [x86_64-linux-6.17.2-1-pve] (local build)
Copyright (C) 2002-23, Bruce Allen, Christian Franke, www.smartmontools.org

ERROR: smartctl takes ONE device name as the final command-line argument.
You have provided 2 device names:
/dev/sda
/dev/sdb

Use smartctl -h to get a usage summary
```
修改后结果如下
```bash
root@pve:~# for disk in /dev/sd[a-z]; do smartctl -a $disk; done | grep -E "Device Model|Capacity|Power_On_Hours|Temperature"
Device Model:     Fanxiang S201 Pro 512GB
User Capacity:    512,110,190,592 bytes [512 GB]
  9 Power_On_Hours          0x0012   100   100   000    Old_age   Always       -       11100
194 Temperature_Celsius     0x0022   043   043   000    Old_age   Always       -       43 (Min/Max 30/50)
Device Model:     TOSHIBA MQ01ABF050
User Capacity:    500,107,862,016 bytes [500 GB]
  9 Power_On_Hours          0x0032   060   060   000    Old_age   Always       -       16396
194 Temperature_Celsius     0x0022   100   100   000    Old_age   Always       -       36 (Min/Max 3/66)
```

<img width="2209" height="973" alt="PixPin_2025-11-26_21-13-12" src="https://github.com/user-attachments/assets/805426b0-6ea5-456c-8c3d-7dce6ffafb17" />
<img width="1520" height="124" alt="PixPin_2025-11-26_21-27-08" src="https://github.com/user-attachments/assets/87d4b905-7a4f-4d2b-b99d-07255a641b62" />

